### PR TITLE
Remove null coalescence for PHP 5.6 compatibility.

### DIFF
--- a/token_help.module
+++ b/token_help.module
@@ -91,8 +91,8 @@ function token_help_devel_view() {
         array('data' => $token),
         array('data' => $token_data['name']),
         array('data' => $token_data['description']),
-        array('data' => $token_data['type'] ?? ''),
-        array('data' => $token_data['deprecated'] ?? ''),
+        array('data' => isset($token_data['type']) ? $token_data['type'] : ''),
+        array('data' => isset($token_data['deprecated'] ) ? $token_data['deprecated'] : ''),
       );
     }
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/token_help/issues/9.